### PR TITLE
Bump streamlit package for memory leak

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ scipy>=1.8.0
 tqdm
 cloudpickle
 pivottablejs
-streamlit==1.28.0
+streamlit==1.32.0
 nbformat>=4.2.0


### PR DESCRIPTION
## Context

We've had memory pressure on one of our deployment of Wise Pizza that ended up being OOM killed

[docs.streamlit.io/library/changelog#version-1320
](https://docs.streamlit.io/library/changelog#version-1320)

> Bug fix: We've plugged a significant memory leak in the coroutine loop. Apps that generate a large number of small messages between client and server will benefit greatly ([#8068](https://github.com/streamlit/streamlit/pull/8068), [#7989](https://github.com/streamlit/streamlit/issues/7989), [#6510](https://github.com/streamlit/streamlit/issues/6510)).

https://discuss.streamlit.io/t/memory-behavior/16374/13

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
