### PR TITLE
Move number of split quantiles from hardwired to node class member

### DIFF
--- a/wise_pizza/solve/tree.py
+++ b/wise_pizza/solve/tree.py
@@ -78,6 +78,8 @@ class ModelNode:
         self.children = None
         self.dim_split = dim_split or {}
         self.model = None
+        # For dimension splitting candidates, hardwired for now
+        self.num_bins = 10
 
     @property
     def depth(self):
@@ -118,7 +120,7 @@ class ModelNode:
                 if np.any(np.isnan(self.df[dim + "_encoded"])):  # pragma: no cover
                     raise ValueError("NaNs in encoded values")
                 # Get split candidates for brute force search
-                deciles = np.array([q / 10.0 for q in range(1, 10)])
+                deciles = np.array([q / self.num_bins for q in range(1, self.num_bins)])
 
                 splits = weighted_quantiles(
                     self.df[dim + "_encoded"], deciles, self.df["weights"]


### PR DESCRIPTION
## Context

Just wanted to make this change before I forget about it, related to https://github.com/cerlymarco/linear-tree/issues/41
## Checklist
- [x ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
